### PR TITLE
Mutiny LDK storage

### DIFF
--- a/node-manager/src/bdkstorage.rs
+++ b/node-manager/src/bdkstorage.rs
@@ -240,7 +240,7 @@ impl Database for MutinyBrowserStorage {
         keychain: Option<KeychainKind>,
     ) -> Result<Vec<Script>, bdk::Error> {
         let key = MapKey::Path((keychain, None)).as_map_key();
-        self.scan_prefix(key)
+        self.scan(key.as_str(), None)
             .into_iter()
             .map(|(_, value)| -> Result<_, bdk::Error> {
                 let str_opt = value.as_str();
@@ -256,7 +256,7 @@ impl Database for MutinyBrowserStorage {
 
     fn iter_utxos(&self) -> Result<Vec<LocalUtxo>, bdk::Error> {
         let key = MapKey::Utxo(None).as_map_key();
-        self.scan_prefix(key)
+        self.scan(key.as_str(), None)
             .into_iter()
             .map(|(_, value)| -> Result<_, bdk::Error> {
                 let utxo: LocalUtxo = Deserialize::deserialize(value)?;
@@ -267,7 +267,7 @@ impl Database for MutinyBrowserStorage {
 
     fn iter_raw_txs(&self) -> Result<Vec<Transaction>, bdk::Error> {
         let key = MapKey::RawTx(None).as_map_key();
-        self.scan_prefix(key)
+        self.scan(key.as_str(), None)
             .into_iter()
             .map(|(_, value)| -> Result<_, bdk::Error> {
                 let tx: Transaction = Deserialize::deserialize(value)?;
@@ -278,7 +278,7 @@ impl Database for MutinyBrowserStorage {
 
     fn iter_txs(&self, include_raw: bool) -> Result<Vec<TransactionDetails>, bdk::Error> {
         let key = MapKey::Transaction(None).as_map_key();
-        self.scan_prefix(key)
+        self.scan(key.as_str(), None)
             .into_iter()
             .map(|(key, value)| -> Result<_, bdk::Error> {
                 let mut tx_details: TransactionDetails = Deserialize::deserialize(value)?;

--- a/node-manager/src/error.rs
+++ b/node-manager/src/error.rs
@@ -44,6 +44,8 @@ pub enum MutinyError {
         #[from]
         source: MutinyStorageError,
     },
+    #[error("Failed to read data from storage.")]
+    ReadError { source: MutinyStorageError },
     /// A wallet operation failed.
     #[error("Failed to conduct wallet operation.")]
     WalletOperationFailed,
@@ -71,6 +73,12 @@ pub enum MutinyStorageError {
     },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
+}
+
+impl MutinyError {
+    pub fn read_err(e: MutinyStorageError) -> Self {
+        MutinyError::ReadError { source: e }
+    }
 }
 
 impl From<bdk::Error> for MutinyError {

--- a/node-manager/src/ldkstorage.rs
+++ b/node-manager/src/ldkstorage.rs
@@ -1,0 +1,135 @@
+use std::io;
+use std::io::Cursor;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use bitcoin::BlockHash;
+use lightning::chain::channelmonitor::ChannelMonitor;
+use lightning::chain::keysinterface::{KeysInterface, Sign};
+use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringParameters};
+use lightning::util::persist::KVStorePersister;
+use lightning::util::ser::{ReadableArgs, Writeable};
+use log::error;
+
+use crate::localstorage::MutinyBrowserStorage;
+use crate::logging::MutinyLogger;
+use crate::node::NetworkGraph;
+
+pub struct MutinyNodePersister {
+    node_id: String,
+    storage: MutinyBrowserStorage,
+}
+
+impl MutinyNodePersister {
+    fn get_key(&self, key: &str) -> String {
+        format!("{}_{}", key, self.node_id)
+    }
+
+    fn read_value(&self, _key: &str) -> Result<Vec<u8>, io::Error> {
+        let key = self.get_key(_key);
+        self.storage.get(key).map_err(io::Error::other)
+    }
+
+    pub fn persist_network_graph(&self, network_graph: &NetworkGraph) -> io::Result<()> {
+        self.persist("network", network_graph)
+    }
+
+    pub fn read_network_graph(
+        &self,
+        genesis_hash: BlockHash,
+        logger: Arc<MutinyLogger>,
+    ) -> NetworkGraph {
+        let (already_init, kv_value) = match self.read_value("network") {
+            Ok(kv_value) => (!kv_value.is_empty(), kv_value),
+            Err(_) => (false, vec![]),
+        };
+
+        if already_init {
+            let mut readable_kv_value = Cursor::new(kv_value);
+            match NetworkGraph::read(&mut readable_kv_value, logger.clone()) {
+                Ok(graph) => graph,
+                Err(e) => {
+                    error!("Error reading NetworkGraph: {}", e.to_string());
+                    NetworkGraph::new(genesis_hash, logger)
+                }
+            }
+        } else {
+            NetworkGraph::new(genesis_hash, logger)
+        }
+    }
+
+    pub fn persist_scorer(
+        &self,
+        scorer: &ProbabilisticScorer<Arc<NetworkGraph>, Arc<MutinyLogger>>,
+    ) -> io::Result<()> {
+        self.persist("prob_scorer", scorer)
+    }
+
+    pub fn read_scorer(
+        &self,
+        graph: Arc<NetworkGraph>,
+        logger: Arc<MutinyLogger>,
+    ) -> ProbabilisticScorer<Arc<NetworkGraph>, Arc<MutinyLogger>> {
+        let params = ProbabilisticScoringParameters::default();
+        let (already_init, kv_value) = match self.read_value("prob_scorer") {
+            Ok(kv_value) => (!kv_value.is_empty(), kv_value),
+            Err(_) => (false, vec![]),
+        };
+
+        if already_init {
+            let mut readable_kv_value = Cursor::new(kv_value);
+            let args = (params.clone(), Arc::clone(&graph), Arc::clone(&logger));
+            match ProbabilisticScorer::read(&mut readable_kv_value, args) {
+                Ok(graph) => graph,
+                Err(e) => {
+                    error!("Error reading ProbabilisticScorer: {}", e.to_string());
+                    ProbabilisticScorer::new(params, graph, logger)
+                }
+            }
+        } else {
+            ProbabilisticScorer::new(params, graph, logger)
+        }
+    }
+
+    pub fn read_channel_monitors<Signer: Sign, K: Deref>(
+        &self,
+        keys_manager: K,
+    ) -> Result<Vec<(BlockHash, ChannelMonitor<Signer>)>, io::Error>
+    where
+        K::Target: KeysInterface<Signer = Signer> + Sized,
+    {
+        let mut res = Vec::new();
+
+        // Get all the channel monitor buffers that exist for this node
+        let suffix = self.node_id.as_str();
+        let channel_monitor_list = self.storage.scan("monitors/", Some(suffix));
+
+        // TODO probably could use a fold here instead
+        for (_, value) in channel_monitor_list {
+            let data = value.to_string();
+            let mut buffer = Cursor::new(data);
+            match <(BlockHash, ChannelMonitor<Signer>)>::read(&mut buffer, &*keys_manager) {
+                Ok((blockhash, channel_monitor)) => {
+                    res.push((blockhash, channel_monitor));
+                }
+                Err(e) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("Failed to deserialize ChannelMonitor: {}", e),
+                    ));
+                }
+            }
+        }
+
+        Ok(res)
+    }
+}
+
+impl KVStorePersister for MutinyNodePersister {
+    fn persist<W: Writeable>(&self, key: &str, object: &W) -> io::Result<()> {
+        let key_with_node = self.get_key(key);
+        self.storage
+            .set(key_with_node, object.encode())
+            .map_err(io::Error::other)
+    }
+}

--- a/node-manager/src/lib.rs
+++ b/node-manager/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(io_error_other)]
 #![allow(non_snake_case, non_upper_case_globals)]
 // wasm_bindgen uses improper casing and it needs to be turned off:
 // https://github.com/rustwasm/wasm-bindgen/issues/2882
@@ -6,6 +7,7 @@ mod bdkstorage;
 mod encrypt;
 mod error;
 mod keymanager;
+mod ldkstorage;
 mod localstorage;
 mod logging;
 mod node;

--- a/node-manager/src/localstorage.rs
+++ b/node-manager/src/localstorage.rs
@@ -47,7 +47,7 @@ impl MutinyBrowserStorage {
     }
 
     // mostly a copy of self.get_all()
-    pub(crate) fn scan_prefix(&self, prefix: String) -> Map<String, Value> {
+    pub(crate) fn scan(&self, prefix: &str, suffix: Option<&str>) -> Map<String, Value> {
         let local_storage = LocalStorage::raw();
         let length = LocalStorage::length();
         let mut map = Map::with_capacity(length as usize);
@@ -55,7 +55,7 @@ impl MutinyBrowserStorage {
             let key_opt: Option<String> = local_storage.key(index).unwrap();
 
             if let Some(key) = key_opt {
-                if key.starts_with(String::as_str(&prefix)) {
+                if key.starts_with(prefix) && (suffix.is_none() || key.ends_with(suffix.unwrap())) {
                     let value: Value = self.get(&key).unwrap();
                     map.insert(key, value);
                 }

--- a/node-manager/src/node.rs
+++ b/node-manager/src/node.rs
@@ -3,12 +3,16 @@ use std::sync::Arc;
 use crate::{
     error::MutinyError,
     keymanager::{create_keys_manager, pubkey_from_keys_manager},
+    logging::MutinyLogger,
     nodemanager::NodeIndex,
 };
 use bip39::Mnemonic;
 use bitcoin::secp256k1::PublicKey;
 use lightning::chain::keysinterface::KeysManager;
+use lightning::routing::gossip;
 use log::info;
+
+pub(crate) type NetworkGraph = gossip::NetworkGraph<Arc<MutinyLogger>>;
 
 pub struct Node {
     pub uuid: String,


### PR DESCRIPTION

Closes #17

I _think_ this is all we need for the ldk storage. A lot of the functions are implemented for us for free using a KV store [here](https://github.com/lightningdevkit/rust-lightning/blob/f4f1093edc506314484c8d52a40dd155e692394b/lightning/src/util/persist.rs)

The main question I had was needing to implement a `read_channel_monitor_updates`. However the default `update_persisted_channel` just overwrites the channel everytime, so I am not sure what the use case of each channel update would be if we are able to safely overwrite while running.
