### PR TITLE
Add basic BroadcasterInterface

### DIFF
--- a/frontend/src/routes/KitchenSink.tsx
+++ b/frontend/src/routes/KitchenSink.tsx
@@ -10,6 +10,8 @@ function App() {
 
     const [balance, setBalance] = useState("0")
 
+    const [tx, setTx] = useState("")
+
     const [address, setAddress] = useState("")
 
     const [nodeManager, setNodeManager] = useState<NodeManager>();
@@ -35,6 +37,10 @@ function App() {
 
     function handleConnectPeerChange(e: React.ChangeEvent<HTMLInputElement>) {
         setConnectPeer(e.target.value);
+    }
+
+    function handleTxChange(e: React.ChangeEvent<HTMLInputElement>) {
+        setTx(e.target.value);
     }
 
     useEffect(() => {
@@ -78,6 +84,15 @@ function App() {
                 setAmount("")
                 setDestinationAddress("")
             }
+        } catch (e) {
+            console.error(e);
+        }
+    }
+
+    async function broadcastTx(e: React.SyntheticEvent) {
+        e.preventDefault()
+        try {
+            await nodeManager?.broadcast_transaction(tx);
         } catch (e) {
             console.error(e);
         }
@@ -147,6 +162,11 @@ function App() {
                             <pre>
                                 <code>Txid: {txid}</code>
                             </pre>
+                        </form>
+                        <form onSubmit={broadcastTx} className="flex flex-col items-start gap-4 my-4">
+                            <h2>Broadcast Tx:</h2>
+                            <input type="text" placeholder='tx' onChange={handleTxChange}></input>
+                            <input type="submit" value="Send" />
                         </form>
                         <pre>
                             <code>{newPubkey}</code>

--- a/node-manager/src/nodemanager.rs
+++ b/node-manager/src/nodemanager.rs
@@ -6,8 +6,11 @@ use crate::node::Node;
 use crate::{localstorage::MutinyBrowserStorage, utils::set_panic_hook, wallet::MutinyWallet};
 use bdk::wallet::AddressIndex;
 use bip39::Mnemonic;
-use bitcoin::Network;
+use bitcoin::consensus::deserialize;
+use bitcoin::hashes::hex::FromHex;
+use bitcoin::{Network, Transaction};
 use futures::lock::Mutex;
+use lightning::chain::chaininterface::BroadcasterInterface;
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -90,6 +93,14 @@ impl NodeManager {
             node_storage: Mutex::new(node_storage),
             nodes: Arc::new(Mutex::new(HashMap::new())), // TODO init the nodes
         }
+    }
+
+    #[wasm_bindgen]
+    pub fn broadcast_transaction(&self, str: String) {
+        let tx_bytes = Vec::from_hex(str.as_str()).unwrap();
+        let tx: Transaction = deserialize(&tx_bytes).unwrap();
+
+        self.wallet.broadcast_transaction(&tx)
     }
 
     #[wasm_bindgen]


### PR DESCRIPTION
Didn't end up needing to do the fancy queue & other stuff. Since this just returns `()` we can just ignore the return of the `broadcast` function and not need to deal with the async. The only problem here is that if it fails to broadcast we won't know, this should be fine for POC but left a `fixme` comment for future reference.