### PR TITLE
Allow generating 12 or 24 word seed phrase

### DIFF
--- a/node-manager/src/error.rs
+++ b/node-manager/src/error.rs
@@ -49,6 +49,9 @@ pub enum MutinyError {
     },
     #[error("Failed to read data from storage.")]
     ReadError { source: MutinyStorageError },
+    /// A failure to generate a mnemonic seed.
+    #[error("Failed to generate seed")]
+    SeedGenerationFailed,
     /// A wallet operation failed.
     #[error("Failed to conduct wallet operation.")]
     WalletOperationFailed,
@@ -162,6 +165,9 @@ pub enum MutinyJsError {
     PersistenceFailed,
     #[error("Failed to read data from storage.")]
     ReadError,
+    /// A failure to generate a mnemonic seed.
+    #[error("Failed to generate seed")]
+    SeedGenerationFailed,
     /// A wallet operation failed.
     #[error("Failed to conduct wallet operation.")]
     WalletOperationFailed,
@@ -192,6 +198,7 @@ impl From<MutinyError> for MutinyJsError {
             MutinyError::ChannelClosingFailed => MutinyJsError::ChannelClosingFailed,
             MutinyError::PersistenceFailed { source: _ } => MutinyJsError::PersistenceFailed,
             MutinyError::ReadError { source: _ } => MutinyJsError::ReadError,
+            MutinyError::SeedGenerationFailed => MutinyJsError::SeedGenerationFailed,
             MutinyError::WalletOperationFailed => MutinyJsError::WalletOperationFailed,
             MutinyError::WalletSigningFailed => MutinyJsError::WalletSigningFailed,
             MutinyError::ChainAccessFailed => MutinyJsError::ChainAccessFailed,

--- a/node-manager/src/nodemanager.rs
+++ b/node-manager/src/nodemanager.rs
@@ -88,10 +88,13 @@ impl NodeManager {
                 };
                 storage.insert_mnemonic(seed)
             }
-            None => storage.get_mnemonic().unwrap_or_else(|_| {
-                let seed = keymanager::generate_seed();
-                storage.insert_mnemonic(seed)
-            }),
+            None => match storage.get_mnemonic() {
+                Ok(mnemonic) => mnemonic,
+                Err(_) => {
+                    let seed = keymanager::generate_seed(12)?;
+                    storage.insert_mnemonic(seed)
+                }
+            },
         };
 
         let wallet = Arc::new(MutinyWallet::new(
@@ -325,7 +328,7 @@ mod tests {
     fn correctly_show_seed() {
         log!("showing seed");
 
-        let seed = generate_seed();
+        let seed = generate_seed(12).expect("Failed to gen seed");
         let nm = NodeManager::new("password".to_string(), Some(seed.to_string())).unwrap();
 
         assert!(NodeManager::has_node_manager());
@@ -338,7 +341,7 @@ mod tests {
     async fn created_new_nodes() {
         log!("creating new nodes");
 
-        let seed = generate_seed();
+        let seed = generate_seed(12).expect("Failed to gen seed");
         let nm = NodeManager::new("password".to_string(), Some(seed.to_string()))
             .expect("node manager should initialize");
 


### PR DESCRIPTION
Made it so `generate_seed()` now results a `Result` so we can handle specific errors if something fails there.

For now made it so the app is hardcoded to generates 12 word seeds. I don't know if we want to make this a parameter later but felt this was good to at least get the internals out of the way for now.