### PR TITLE
Fix bug with non-empty string password

### DIFF
--- a/node-manager/src/bdkstorage.rs
+++ b/node-manager/src/bdkstorage.rs
@@ -363,7 +363,7 @@ impl BatchDatabase for MutinyBrowserStorage {
     type Batch = Self;
 
     fn begin_batch(&self) -> Self::Batch {
-        MutinyBrowserStorage::new("".to_string())
+        MutinyBrowserStorage::new(self.clone().password)
     }
 
     fn commit_batch(&mut self, mut _batch: Self::Batch) -> Result<(), bdk::Error> {

--- a/node-manager/src/localstorage.rs
+++ b/node-manager/src/localstorage.rs
@@ -18,7 +18,7 @@ const fee_estimates_key: &str = "fee_estimates";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MutinyBrowserStorage {
-    password: String,
+    pub(crate) password: String,
 }
 
 impl MutinyBrowserStorage {


### PR DESCRIPTION
I think this would break if you were using any password that wasn't `""`