### PR TITLE
Remove mutex around bdk wallet

### DIFF
--- a/node-manager/src/event.rs
+++ b/node-manager/src/event.rs
@@ -462,8 +462,6 @@ impl LdkEventHandler for EventHandler {
                 spawn_local(async move {
                     let destination_address = wallet_thread
                         .wallet
-                        .lock()
-                        .await
                         .get_address(AddressIndex::New)
                         .expect("could not get new address");
 

--- a/node-manager/src/node.rs
+++ b/node-manager/src/node.rs
@@ -49,7 +49,7 @@ use lightning::routing::scoring::{ProbabilisticScorer, ProbabilisticScoringParam
 use lightning::util::config::{ChannelHandshakeConfig, ChannelHandshakeLimits, UserConfig};
 use lightning_invoice::utils::DefaultRouter;
 use lightning_invoice::{payment, Invoice};
-use log::{debug, error, info, trace, warn};
+use log::{error, info, trace, warn};
 
 pub(crate) type NetworkGraph = gossip::NetworkGraph<Arc<MutinyLogger>>;
 

--- a/node-manager/src/nodemanager.rs
+++ b/node-manager/src/nodemanager.rs
@@ -338,13 +338,7 @@ impl NodeManager {
 
     #[wasm_bindgen]
     pub async fn get_new_address(&self) -> Result<String, MutinyJsError> {
-        match self
-            .wallet
-            .wallet
-            .lock()
-            .await
-            .get_address(AddressIndex::New)
-        {
+        match self.wallet.wallet.get_address(AddressIndex::New) {
             Ok(addr) => Ok(addr.address.to_string()),
             Err(_) => Err(MutinyError::WalletOperationFailed.into()),
         }
@@ -352,7 +346,7 @@ impl NodeManager {
 
     #[wasm_bindgen]
     pub async fn get_wallet_balance(&self) -> Result<u64, MutinyJsError> {
-        match self.wallet.wallet.lock().await.get_balance() {
+        match self.wallet.wallet.get_balance() {
             Ok(balance) => Ok(balance.get_total()),
             Err(_) => Err(MutinyJsError::WalletOperationFailed),
         }
@@ -410,23 +404,23 @@ impl NodeManager {
     }
 
     #[wasm_bindgen]
-    pub async fn list_onchain(&self) -> Result<JsValue, MutinyJsError> {
-        let txs = self.wallet.list_transactions(false).await?;
+    pub fn list_onchain(&self) -> Result<JsValue, MutinyJsError> {
+        let txs = self.wallet.list_transactions(false)?;
 
         Ok(serde_wasm_bindgen::to_value(&txs)?)
     }
 
     #[wasm_bindgen]
-    pub async fn get_transaction(&self, txid: String) -> Result<JsValue, MutinyJsError> {
+    pub fn get_transaction(&self, txid: String) -> Result<JsValue, MutinyJsError> {
         let txid = Txid::from_str(txid.as_str())?;
-        let txs = self.wallet.get_transaction(txid, false).await?;
+        let txs = self.wallet.get_transaction(txid, false)?;
 
         Ok(serde_wasm_bindgen::to_value(&txs)?)
     }
 
     #[wasm_bindgen]
     pub async fn get_balance(&self) -> Result<MutinyBalance, MutinyJsError> {
-        match self.wallet.wallet.lock().await.get_balance() {
+        match self.wallet.wallet.get_balance() {
             Ok(onchain) => {
                 let nodes = self.nodes.lock().await;
                 let lightning_msats: u64 = nodes
@@ -447,8 +441,8 @@ impl NodeManager {
     }
 
     #[wasm_bindgen]
-    pub async fn list_utxos(&self) -> Result<JsValue, MutinyJsError> {
-        let utxos = self.wallet.list_utxos().await?;
+    pub fn list_utxos(&self) -> Result<JsValue, MutinyJsError> {
+        let utxos = self.wallet.list_utxos()?;
 
         Ok(serde_wasm_bindgen::to_value(&utxos)?)
     }


### PR DESCRIPTION
Seems we need to remove this mutex to do any DLC stuff as all of rust-dlcs definitions aren't async. I don't totally remember why we used a mutex here, the wallet seems to work fine without it. I did need to do the `unsafe impl Send` and `unsafe impl Sync` for `MutinyWallet` but that should be fine in wasm anyways