### PR TITLE
Don't have change outputs count as unconfirmed balance

### DIFF
--- a/node-manager/src/nodemanager.rs
+++ b/node-manager/src/nodemanager.rs
@@ -514,8 +514,8 @@ impl NodeManager {
                     .sum();
 
                 Ok(MutinyBalance {
-                    confirmed: onchain.confirmed,
-                    unconfirmed: onchain.untrusted_pending + onchain.trusted_pending,
+                    confirmed: onchain.confirmed + onchain.trusted_pending,
+                    unconfirmed: onchain.untrusted_pending + onchain.immature,
                     lightning: lightning_msats / 1000,
                 })
             }


### PR DESCRIPTION
I think this is slightly better UX where when you send it doesn't immediately make it look like your entire wallet balance is now unconfirmed.

Also included `immature` to unconfirmed balance, probably will never be relevant but may as well