### PR TITLE
Sort transactions in rust rather than in javascript

### DIFF
--- a/frontend/src/routes/OnChain.tsx
+++ b/frontend/src/routes/OnChain.tsx
@@ -45,19 +45,6 @@ const SingleTransaction = ({ tx, network }: { tx: OnChainTx, network?: string })
     )
 }
 
-// Sort by timestamp, but if there's no timestamp put it first
-function sortTx(a: OnChainTx, b: OnChainTx) {
-    if (b.confirmation_time && a.confirmation_time) {
-        return b.confirmation_time.timestamp - a.confirmation_time.timestamp
-    } else if (a.confirmation_time) {
-        return 1
-    } else if (b.confirmation_time) {
-        return -1
-    } else {
-        return a.txid.localeCompare(b.txid)
-    }
-}
-
 function OnChain() {
     const { nodeManager } = useContext(NodeManagerContext);
 
@@ -80,7 +67,7 @@ function OnChain() {
             </header>
             <ScreenMain padSides={false} wontScroll={!transactions || transactions.length < 4}>
                 <ul className="overflow-y-scroll h-full px-8 pb-[12rem]">
-                    {transactions?.sort(sortTx).map(tx => (
+                    {transactions?.map(tx => (
                         <SingleTransaction key={tx.txid} tx={tx} network={nodeManager?.get_network()} />
                     ))}
                 </ul>

--- a/node-manager/src/nodemanager.rs
+++ b/node-manager/src/nodemanager.rs
@@ -489,7 +489,17 @@ impl NodeManager {
 
     #[wasm_bindgen]
     pub async fn list_onchain(&self) -> Result<JsValue, MutinyJsError> {
-        let txs = self.wallet.list_transactions(false).await?;
+        let mut txs = self.wallet.list_transactions(false).await?;
+
+        // Sort by timestamp, but if there's no timestamp put it first,
+        // if timestamps are equal, compare by txid
+        txs.sort_by(|a, b| {
+            a.confirmation_time
+                .as_ref()
+                .map(|c| c.timestamp)
+                .cmp(&b.confirmation_time.as_ref().map(|c| c.timestamp))
+                .then_with(|| a.txid.cmp(&b.txid))
+        });
 
         Ok(serde_wasm_bindgen::to_value(&txs)?)
     }


### PR DESCRIPTION
Before my on-chain txs were jumping around in ordering. Tried to fix in the javascript sort function but kept getting issues (not sure why, maybe javascript number stuff). Changed to sort from the rust code and it fixed, this is probably better in the long run anyways