### PR TITLE
Turn off Qr scanner after pasting from clipboard

### DIFF
--- a/frontend/src/components/ReceiveUnified.tsx
+++ b/frontend/src/components/ReceiveUnified.tsx
@@ -14,8 +14,8 @@ export default function ReceiveUnified({ bip21String }: { bip21String: string })
 
     const { address, options } = bip21.decode(bip21String) as MutinyBip21;
 
-    const { isLoading: isCheckingAddress } = useQuery({
-        queryKey: ['checktransaction'],
+    useQuery({
+        queryKey: ['checktransaction', address],
         queryFn: async () => {
             console.log("Checking address:", address);
             const tx = await nodeManager?.check_address(address);
@@ -28,11 +28,12 @@ export default function ReceiveUnified({ bip21String }: { bip21String: string })
             }
         },
         enabled: !!address,
+        refetchOnMount: "always",
         refetchInterval: 1000
     })
 
     useQuery({
-        queryKey: ['checkinvoice'],
+        queryKey: ['checkinvoice', options.lightning],
         queryFn: async () => {
             if (options.lightning) {
                 let invoice = await nodeManager?.decode_invoice(options.lightning);
@@ -51,6 +52,7 @@ export default function ReceiveUnified({ bip21String }: { bip21String: string })
             }
         },
         enabled: !!options.lightning,
+        refetchOnMount: "always",
         refetchInterval: 1000
     })
 
@@ -59,20 +61,19 @@ export default function ReceiveUnified({ bip21String }: { bip21String: string })
             {bip21 &&
                 <>
                     <div className="bg-[#ffffff] p-4">
-                        <QRCode level="M" value={bip21String.toUpperCase()} />
+                        <QRCode level="M" value={bip21String ? bip21String.toUpperCase() : ""} />
                     </div>
                     <div className="flex items-center gap-2 w-full">
                         {/* <p className="text-lg font-mono font-light break-all"> */}
                         <pre className="flex-1">
                             <code className="break-all whitespace-nowrap overflow-hidden overflow-ellipsis">
-                                {takeN(bip21String, 28)}
+                                {takeN(bip21String ?? "", 28)}
                             </code>
                         </pre>
                         <div className="flex-0">
-                            <Copy copyValue={bip21String} />
+                            <Copy copyValue={bip21String ?? ""} />
                         </div>
                     </div>
-                    <p className="text-2xl font-light"> {isCheckingAddress ? "Checking..." : "Checking"}</p>
                 </>
             }
         </>

--- a/frontend/src/routes/ReceiveFinal.tsx
+++ b/frontend/src/routes/ReceiveFinal.tsx
@@ -4,7 +4,7 @@ import ScreenMain from "../components/ScreenMain";
 import { useNavigate } from "react-router";
 import { useContext } from "react";
 import { NodeManagerContext } from "@components/GlobalStateProvider";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import takeN from "@util/takeN";
 import prettyPrintTime from "@util/prettyPrintTime";
 import { useSearchParams } from "react-router-dom";
@@ -15,6 +15,7 @@ import ActionButton from "@components/ActionButton";
 
 export default function ReceiveFinal() {
     let navigate = useNavigate();
+    const queryClient = useQueryClient()
 
     const { nodeManager } = useContext(NodeManagerContext);
 
@@ -38,7 +39,6 @@ export default function ReceiveFinal() {
         },
         enabled: !!(nodeManager && address),
         refetchOnWindowFocus: false,
-        refetchInterval: 1000
     })
 
     const { data: lightning } = useQuery({
@@ -51,6 +51,7 @@ export default function ReceiveFinal() {
     })
 
     function handleGoHome() {
+        queryClient.invalidateQueries({ queryKey: ['balance'] })
         navigate("/")
     }
 

--- a/frontend/src/routes/ReceiveQR.tsx
+++ b/frontend/src/routes/ReceiveQR.tsx
@@ -38,7 +38,7 @@ export default function ReceiveQR() {
         navigate("/")
     }
 
-    const { data: bip21RawMaterial } = useQuery({
+    const { isLoading, data: bip21RawMaterial } = useQuery({
         // By making amount and description keys, they should automatically redo the query when they change
         queryKey: ['bip21', amount, description],
         queryFn: () => {
@@ -55,7 +55,9 @@ export default function ReceiveQR() {
         },
         enabled: !!nodeManager,
         // Don't want a new address each time they focus the window
-        refetchOnWindowFocus: false
+        refetchOnWindowFocus: false,
+        // Important! Without this, it will use a stale version of bip21RawMaterial which has already been paid
+        cacheTime: 0
     })
 
 
@@ -67,7 +69,10 @@ export default function ReceiveQR() {
             </header>
             <ScreenMain>
                 <div />
-                {bip21RawMaterial &&
+                {isLoading &&
+                    <p className="text-2xl font-light">Loading...</p>
+                }
+                {bip21RawMaterial && !isLoading &&
                     <div className="flex flex-col items-start gap-4">
                         <ReceiveUnified bip21String={formatBip21RawMaterial(bip21RawMaterial)} />
                     </div>


### PR DESCRIPTION
As noted in issue #190 the qr scanner doesn't properly turn off when pasting an address from a clipboard and only on a successful qr scan.  
Upon troubleshooting this problem i discovered it seemed to do with the fact that the input box and the QrCodeSanner component were separate and joined together in the send route. The qr scanner is only looking for valid data scanned from the qr code and not valid data typed in the input field. At first I attempted to import the qrCodeRef to find the existing qr scan and then kill it upon calling the handleContinue() function of the send route with,
`qrCodeRef.current?.stop()`
however, I was not able to get react to successfully identify the qr scanner that was started in the separate component so I instead decide to build matching logic for the input field inside of the QrCodeScanner component to ensure that when the continue button is pressed it can find and kill the existing qr scanner.
Lastly I added a small amount of styling because that qr scanner is too damn BIG!

I am happy that it works but would have liked to simplify the logic and not double up the code :sweat_smile: just thought I'd give a hand at fixing this bug that i thought could be fixed more easily.
If there is a way to find and kill the Qr scanner from outside of the component this code could be much more simplified.