### PR TITLE
Hex encode ldk sorage items

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   Deploy-Preview:
+    environment: Preview
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -8,6 +8,7 @@ on:
       - master
 jobs:
   Deploy-Production:
+    environment: Production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/node-manager/src/ldkstorage.rs
+++ b/node-manager/src/ldkstorage.rs
@@ -349,7 +349,7 @@ impl KVStorePersister for MutinyNodePersister {
     fn persist<W: Writeable>(&self, key: &str, object: &W) -> io::Result<()> {
         let key_with_node = self.get_key(key);
         self.storage
-            .set(key_with_node, object.encode())
+            .set(key_with_node, object.encode().to_hex())
             .map_err(io::Error::other)
     }
 }


### PR DESCRIPTION
Before it would store things byte arrays like: `[1,1,0,0,0,0,0,0,0,15,108,103,13...]`
Now it will be hex, should use less space