### PR TITLE
Use node manager's esplora instead of wallets when checking address

### DIFF
--- a/node-manager/src/nodemanager.rs
+++ b/node-manager/src/nodemanager.rs
@@ -484,7 +484,7 @@ impl NodeManager {
         address: String,
     ) -> Result<JsValue /* Option<TransactionDetails> */, MutinyJsError> {
         let script = Address::from_str(address.as_str())?.payload.script_pubkey();
-        let txs = self.wallet.blockchain.scripthash_txs(&script, None).await?;
+        let txs = self.esplora.scripthash_txs(&script, None).await?;
 
         let details_opt = txs.first().map(|tx| {
             let received: u64 = tx


### PR DESCRIPTION
We shouldn't need to grab the wallet's esplora instance here when we have one in the node manager