### PR TITLE
Reduce unneeded derivation in create_keys_manager

### DIFF
--- a/node-manager/src/keymanager.rs
+++ b/node-manager/src/keymanager.rs
@@ -37,10 +37,7 @@ pub(crate) fn create_keys_manager(mnemonic: Mnemonic, child_index: u32) -> Phant
         .derive_child(bip32::ChildNumber::new(0, true).unwrap())
         .unwrap();
 
-    let xpriv = XPrv::new(mnemonic.to_seed(""))
-        .unwrap()
-        .derive_child(bip32::ChildNumber::new(0, true).unwrap())
-        .unwrap()
+    let xpriv = shared_key
         .derive_child(bip32::ChildNumber::new(child_index, true).unwrap())
         .unwrap();
 


### PR DESCRIPTION
The removed section is the same as `shared_key` so we can just use that so we don't need to re-derive the key