### PR TITLE
Fix LDK syncing

### DIFF
--- a/node-manager/src/chain.rs
+++ b/node-manager/src/chain.rs
@@ -10,7 +10,7 @@ use lightning::chain::chaininterface::{
     BroadcasterInterface, ConfirmationTarget, FeeEstimator, FEERATE_FLOOR_SATS_PER_KW,
 };
 use lightning::chain::{Confirm, Filter, WatchedOutput};
-use log::{debug, error, info};
+use log::{debug, error, info, trace};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use wasm_bindgen_futures::spawn_local;
@@ -374,7 +374,7 @@ impl FeeEstimator for MutinyChain {
                 let found = estimates.get(num_blocks.to_string().as_str());
                 match found {
                     Some(num) => {
-                        info!("Got fee rate from saved cache!");
+                        trace!("Got fee rate from saved cache!");
                         let satsVbyte = num.to_owned() as f32;
                         let fee_rate = FeeRate::from_sat_per_vb(satsVbyte);
                         (fee_rate.fee_wu(1000) as u32).max(FEERATE_FLOOR_SATS_PER_KW)

--- a/node-manager/src/node.rs
+++ b/node-manager/src/node.rs
@@ -225,6 +225,9 @@ impl Node {
         if read_channel_manager.is_restarting {
             let mut chain_listener_channel_monitors = Vec::new();
             for (blockhash, channel_monitor) in read_channel_manager.channel_monitors.drain(..) {
+                // Get channel monitor ready to sync
+                channel_monitor.load_outputs_to_watch(&chain);
+
                 let outpoint = channel_monitor.get_funding_txo().0;
                 chain_listener_channel_monitors.push((
                     blockhash,


### PR DESCRIPTION
We would never register channels to watch on restart, a potential cause of the force closures, this made it so I could actually sweep the funds from a force closure