### PR TITLE
fix typescript

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -22,5 +22,5 @@
       "@util/*": ["./src/utility/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "../node-manager/pkg/*.d.ts"]
 }


### PR DESCRIPTION
this fixes typescript's "Cannot find module or its corresponding type declarations" warning on `node-manager`