### PR TITLE
Persist all peers and make peer manager abstracted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ debug/
 target/
 ./*/Cargo.lock
 Cargo.lock
+.vim/

--- a/node-manager/src/lib.rs
+++ b/node-manager/src/lib.rs
@@ -17,6 +17,7 @@ mod localstorage;
 mod logging;
 mod node;
 mod nodemanager;
+mod peermanager;
 mod proxy;
 mod socket;
 mod utils;

--- a/node-manager/src/peermanager.rs
+++ b/node-manager/src/peermanager.rs
@@ -1,8 +1,56 @@
 use crate::{ldkstorage::PhantomChannelManager, logging::MutinyLogger, socket::WsSocketDescriptor};
+use bitcoin::secp256k1::PublicKey;
+use lightning::ln::msgs::NetAddress;
+use lightning::ln::peer_handler::PeerHandleError;
 use lightning::ln::peer_handler::{IgnoringMessageHandler, PeerManager as LdkPeerManager};
 use std::sync::Arc;
 
-pub(crate) type PeerManager = LdkPeerManager<
+pub(crate) trait PeerManager {
+    fn get_peer_node_ids(&self) -> Vec<PublicKey>;
+
+    fn new_outbound_connection(
+        &self,
+        their_node_id: PublicKey,
+        descriptor: WsSocketDescriptor,
+        remote_network_address: Option<NetAddress>,
+    ) -> Result<Vec<u8>, PeerHandleError>;
+
+    fn new_inbound_connection(
+        &self,
+        descriptor: WsSocketDescriptor,
+        remote_network_address: Option<NetAddress>,
+    ) -> Result<(), PeerHandleError>;
+
+    fn write_buffer_space_avail(
+        &self,
+        descriptor: &mut WsSocketDescriptor,
+    ) -> Result<(), PeerHandleError>;
+
+    fn read_event(
+        &self,
+        descriptor: &mut WsSocketDescriptor,
+        data: &[u8],
+    ) -> Result<bool, PeerHandleError>;
+
+    fn process_events(&self);
+
+    fn socket_disconnected(&self, descriptor: &mut WsSocketDescriptor);
+
+    fn disconnect_by_node_id(&self, node_id: PublicKey, no_connection_possible: bool);
+
+    fn disconnect_all_peers(&self);
+
+    fn timer_tick_occurred(&self);
+
+    fn broadcast_node_announcement(
+        &self,
+        rgb: [u8; 3],
+        alias: [u8; 32],
+        addresses: Vec<NetAddress>,
+    );
+}
+
+pub(crate) type PeerManagerImpl = LdkPeerManager<
     WsSocketDescriptor,
     Arc<PhantomChannelManager>,
     Arc<IgnoringMessageHandler>,
@@ -10,3 +58,70 @@ pub(crate) type PeerManager = LdkPeerManager<
     Arc<MutinyLogger>,
     Arc<IgnoringMessageHandler>,
 >;
+
+impl PeerManager for PeerManagerImpl {
+    fn get_peer_node_ids(&self) -> Vec<PublicKey> {
+        self.get_peer_node_ids()
+    }
+
+    fn new_outbound_connection(
+        &self,
+        their_node_id: PublicKey,
+        descriptor: WsSocketDescriptor,
+        remote_network_address: Option<NetAddress>,
+    ) -> Result<Vec<u8>, PeerHandleError> {
+        self.new_outbound_connection(their_node_id, descriptor, remote_network_address)
+    }
+
+    fn new_inbound_connection(
+        &self,
+        descriptor: WsSocketDescriptor,
+        remote_network_address: Option<NetAddress>,
+    ) -> Result<(), PeerHandleError> {
+        self.new_inbound_connection(descriptor, remote_network_address)
+    }
+
+    fn write_buffer_space_avail(
+        &self,
+        descriptor: &mut WsSocketDescriptor,
+    ) -> Result<(), PeerHandleError> {
+        self.write_buffer_space_avail(descriptor)
+    }
+
+    fn read_event(
+        &self,
+        peer_descriptor: &mut WsSocketDescriptor,
+        data: &[u8],
+    ) -> Result<bool, PeerHandleError> {
+        self.read_event(peer_descriptor, data)
+    }
+
+    fn process_events(&self) {
+        self.process_events()
+    }
+
+    fn socket_disconnected(&self, descriptor: &mut WsSocketDescriptor) {
+        self.socket_disconnected(descriptor)
+    }
+
+    fn disconnect_by_node_id(&self, node_id: PublicKey, no_connection_possible: bool) {
+        self.disconnect_by_node_id(node_id, no_connection_possible)
+    }
+
+    fn disconnect_all_peers(&self) {
+        self.disconnect_all_peers()
+    }
+
+    fn timer_tick_occurred(&self) {
+        self.timer_tick_occurred()
+    }
+
+    fn broadcast_node_announcement(
+        &self,
+        rgb: [u8; 3],
+        alias: [u8; 32],
+        addresses: Vec<NetAddress>,
+    ) {
+        self.broadcast_node_announcement(rgb, alias, addresses)
+    }
+}

--- a/node-manager/src/peermanager.rs
+++ b/node-manager/src/peermanager.rs
@@ -1,0 +1,12 @@
+use crate::{ldkstorage::PhantomChannelManager, logging::MutinyLogger, socket::WsSocketDescriptor};
+use lightning::ln::peer_handler::{IgnoringMessageHandler, PeerManager as LdkPeerManager};
+use std::sync::Arc;
+
+pub(crate) type PeerManager = LdkPeerManager<
+    WsSocketDescriptor,
+    Arc<PhantomChannelManager>,
+    Arc<IgnoringMessageHandler>,
+    Arc<IgnoringMessageHandler>,
+    Arc<MutinyLogger>,
+    Arc<IgnoringMessageHandler>,
+>;

--- a/node-manager/src/socket.rs
+++ b/node-manager/src/socket.rs
@@ -1,4 +1,4 @@
-use crate::node::PeerManager;
+use crate::peermanager::PeerManager;
 use crate::proxy::Proxy;
 use crate::utils;
 use crossbeam_channel::{unbounded, Receiver, Sender};


### PR DESCRIPTION
Gonna need to do this for all the structures being saved onto the `node` so we can test things better on our node implementation. I'll do those in separate PR's just like this if it's okay.

Need to do this in order to test the thing I was changing originally. 