### PR TITLE
Update bdk to v0.26.0

### DIFF
--- a/node-manager/Cargo.toml
+++ b/node-manager/Cargo.toml
@@ -22,7 +22,7 @@ js-sys = "0.3.60"
 secp256k1 = "0.24.0"
 bitcoin_hashes = { version = "0.11", default-features = false }
 bitcoin = { version = "0.29.2", features = ["serde"] }
-bdk = { version = "0.25", default-features = false, features = ["keys-bip39", "esplora", "use-esplora-reqwest"] }
+bdk = { version = "0.26.0", default-features = false, features = ["keys-bip39", "esplora", "use-esplora-reqwest"] }
 bdk-macros = "0.6.0"
 getrandom = { version = "0.2", features = ["js"] }
 serde = { version = "^1.0", features = ["derive"] }

--- a/node-manager/src/nodemanager.rs
+++ b/node-manager/src/nodemanager.rs
@@ -545,16 +545,7 @@ impl NodeManager {
     #[wasm_bindgen]
     pub async fn list_onchain(&self) -> Result<JsValue, MutinyJsError> {
         let mut txs = self.wallet.list_transactions(false).await?;
-
-        // Sort by timestamp, but if there's no timestamp put it first,
-        // if timestamps are equal, compare by txid
-        txs.sort_by(|a, b| {
-            a.confirmation_time
-                .as_ref()
-                .map(|c| c.timestamp)
-                .cmp(&b.confirmation_time.as_ref().map(|c| c.timestamp))
-                .then_with(|| a.txid.cmp(&b.txid))
-        });
+        txs.sort();
 
         Ok(serde_wasm_bindgen::to_value(&txs)?)
     }


### PR DESCRIPTION
In 0.26 bdk added the transaction sorting we were doing, so now we can just call `.sort`

It also updated the esplora dep so we can now use the same code from https://github.com/lightningdevkit/rust-lightning/pull/1870 